### PR TITLE
Add optional boundaries to getregistrationreceipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -2753,7 +2753,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]

--- a/watchtower-plugin/src/constants.rs
+++ b/watchtower-plugin/src/constants.rs
@@ -4,11 +4,11 @@ pub const DEFAULT_TOWERS_DATA_DIR: &str = ".watchtower";
 
 /// Collections of plugin option names, default values and descriptions
 pub const DEFAULT_SUBSCRIPTION_START: Option<i64> = None;
-pub const SUBSCRIPTION_START: &str = "subscription start";
-pub const SUBSCRIPTION_START_DESC: &str = "subscription start";
+pub const SUBSCRIPTION_START: &str = "subscription-start";
+pub const SUBSCRIPTION_START_DESC: &str = "subscription-start";
 pub const DEFAULT_SUBSCRIPTION_EXPIRY: Option<i64> = None;
-pub const SUBSCRIPTION_EXPIRY: &str = "subscription expiry";
-pub const SUBSCRIPTION_EXPIRY_DESC: &str = "subscription expiry";
+pub const SUBSCRIPTION_EXPIRY: &str = "subscription-expiry";
+pub const SUBSCRIPTION_EXPIRY_DESC: &str = "subscription-expiry";
 
 pub const WT_PORT: &str = "watchtower-port";
 pub const DEFAULT_WT_PORT: i64 = 9814;

--- a/watchtower-plugin/src/constants.rs
+++ b/watchtower-plugin/src/constants.rs
@@ -3,6 +3,12 @@ pub const TOWERS_DATA_DIR: &str = "TOWERS_DATA_DIR";
 pub const DEFAULT_TOWERS_DATA_DIR: &str = ".watchtower";
 
 /// Collections of plugin option names, default values and descriptions
+pub const DEFAULT_SUBSCRIPTION_START: Option<i64> = None;
+pub const SUBSCRIPTION_START: &str = "subscription start";
+pub const SUBSCRIPTION_START_DESC: &str = "subscription start";
+pub const DEFAULT_SUBSCRIPTION_EXPIRY: Option<i64> = None;
+pub const SUBSCRIPTION_EXPIRY: &str = "subscription expiry";
+pub const SUBSCRIPTION_EXPIRY_DESC: &str = "subscription expiry";
 
 pub const WT_PORT: &str = "watchtower-port";
 pub const DEFAULT_WT_PORT: i64 = 9814;

--- a/watchtower-plugin/src/dbm.rs
+++ b/watchtower-plugin/src/dbm.rs
@@ -779,12 +779,14 @@ mod tests {
         let tower_id = get_random_user_id();
         let net_addr = "talaia.watch";
         let receipt = get_random_registration_receipt();
+        let subscription_start = None;
+        let subscription_expiry = None;
 
         // Store it once
         dbm.store_tower_record(tower_id, net_addr, &receipt)
             .unwrap();
         assert_eq!(
-            dbm.load_registration_receipt(tower_id, receipt.user_id(), None, None)
+            dbm.load_registration_receipt(tower_id, receipt.user_id(), subscription_start, subscription_expiry)
             .unwrap(),
             receipt
             );

--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -143,12 +143,14 @@ async fn get_registration_receipt(
 
     let state = plugin.state().lock().unwrap();
 
-    let response = state.get_registration_receipt(tower_id, subscription_start, subscription_expiry).map_err(|_| {
-        anyhow!(
-            "Cannot find {} within the known towers. Have you registered?",
-            tower_id
-        )
-    })?;
+    let response = state
+        .get_registration_receipt(tower_id, subscription_start, subscription_expiry)
+        .map_err(|_| {
+            anyhow!(
+                "Cannot find {} within the known towers. Have you registered?",
+                tower_id
+            )
+        })?;
 
     Ok(json!(response))
 }

--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -293,8 +293,8 @@ async fn get_tower_info(
     plugin: Plugin<Arc<Mutex<WTClient>>>,
     v: serde_json::Value,
 ) -> Result<serde_json::Value, Error> {
-    let state = plugin.state().lock().unwrap();
     let tower_id = TowerId::try_from(v).map_err(|e| anyhow!(e))?;
+    let state = plugin.state().lock().unwrap();
     let tower_info = state.load_tower_info(tower_id).map_err(|_| {
         anyhow!(
             "Cannot find {} within the known towers. Have you registered?",
@@ -526,12 +526,12 @@ async fn main() -> Result<(), Error> {
     let builder = Builder::new(stdin(), stdout())
         .option(ConfigOption::new(
             constants::SUBSCRIPTION_START,
-            Value::Integer(constants::DEFAULT_SUBSCRIPTION_START.unwrap() as i64),
+            Value::OptInteger,
             constants::SUBSCRIPTION_START_DESC,
         ))
         .option(ConfigOption::new(
             constants::SUBSCRIPTION_EXPIRY,
-            Value::Integer(constants::DEFAULT_SUBSCRIPTION_EXPIRY.unwrap() as i64),
+            Value::OptInteger,
             constants::SUBSCRIPTION_EXPIRY_DESC,
         ))
         .option(ConfigOption::new(

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -186,8 +186,10 @@ impl WTClient {
     pub fn get_registration_receipt(
         &self,
         tower_id: TowerId,
+        subscription_start: Option<u32>,
+        subscription_expiry: Option<u32>
     ) -> Result<RegistrationReceipt, DBError> {
-        self.dbm.load_registration_receipt(tower_id, self.user_id)
+        self.dbm.load_registration_receipt(tower_id, self.user_id, subscription_start, subscription_expiry)
     }
 
     /// Loads a tower record from the database.

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -187,9 +187,14 @@ impl WTClient {
         &self,
         tower_id: TowerId,
         subscription_start: Option<u32>,
-        subscription_expiry: Option<u32>
+        subscription_expiry: Option<u32>,
     ) -> Result<RegistrationReceipt, DBError> {
-        self.dbm.load_registration_receipt(tower_id, self.user_id, subscription_start, subscription_expiry)
+        self.dbm.load_registration_receipt(
+            tower_id,
+            self.user_id,
+            subscription_start,
+            subscription_expiry,
+        )
     }
 
     /// Loads a tower record from the database.


### PR DESCRIPTION
Fixes - #97

``load_registration_receipt`` and ``get_registration_receipt`` functions have been updated to accept the optional arguments - subscription-start and subscription-expiry.